### PR TITLE
cleanup description

### DIFF
--- a/src/griffe_fieldz/_extension.py
+++ b/src/griffe_fieldz/_extension.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import inspect
+import textwrap
 from operator import ge
 from typing import TYPE_CHECKING, Any, Iterable, Sequence
 
@@ -119,10 +120,11 @@ def _fields_to_params(
     params: list[DocstringParameter] = []
     attrs: list[DocstringAttribute] = []
     for field in fields:
+        description = field.description or field.metadata.get("description", "")
         kwargs: dict = {
             "name": field.name,
             "annotation": _to_annotation(field.type, docstring),
-            "description": field.description or field.metadata.get("description", ""),
+            "description": textwrap.dedent(description).strip(),
             "value": _default_repr(field),
         }
         if field.init:


### PR DESCRIPTION
This PR applies some text cleaning to the `description` param using [textwrap.dedent](https://docs.python.org/3/library/textwrap.html#textwrap.dedent) + `strip`. This came up on a project of mine where I stored shared field descriptions on a class namespace

```python
from pydantic import BaseModel, Field


class CommonDescriptions:
    field_name = """
    This is a multiline field description for the `field_name`
    field. It requires some text cleaning to show up in docs the right way
    """


class Model(BaseModel):
    field_name: str = Field(description=CommonDescriptions.field_name)


class AnotherModel(BaseModel):
    field_name: str = Field(description=CommonDescriptions.field_name)
```

P.S. This is an awesome project - it really is helping take my docs to the next level with mkdocstrings. 